### PR TITLE
[codex] Polish website delight moments

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,17 @@
+## Design Context
+
+### Users
+Shadow is for developers pairing, interviewing, reviewing, or debugging together across different editors. They are often in the middle of real work and want a fast, trustworthy way to share a project without account setup, editor lock-in, or screen-share lag.
+
+### Brand Personality
+Direct, technical, and lightly irreverent. Shadow should feel like a sharp native developer tool: private by default, low-friction, and respectful of a user's existing setup.
+
+### Aesthetic Direction
+Dark macOS-native utility with warm amber signal color, precise typography, restrained motion, and product-real surfaces. The interface should feel confident and polished, not playful for its own sake. Delight should come from speed, clarity, subtle state changes, and useful confirmations.
+
+### Design Principles
+- Keep the user's editor autonomy as the central emotional promise.
+- Treat security and encryption as quiet confidence, not fear-based marketing.
+- Use motion to explain state and reward completion, never to slow the workflow.
+- Prefer useful microcopy over jokes; wit should be specific to pairing and setup friction.
+- Preserve the native-tool feeling with compact controls, stable layout, and accessible reduced-motion behavior.

--- a/website/src/components/AppMockup.astro
+++ b/website/src/components/AppMockup.astro
@@ -28,6 +28,14 @@ const base = rawBase.endsWith('/') ? rawBase : rawBase + '/';
         <button class="mac-btn mac-btn-secondary" type="button" tabindex="-1">Join Session</button>
       </div>
 
+      <div class="session-card" aria-hidden="true">
+        <div class="session-status">
+          <span class="status-dot"></span>
+          <span>Invite copied</span>
+        </div>
+        <code>shadow.dev/join#e2e-key</code>
+      </div>
+
       <label class="checkbox-row">
         <span class="checkbox-box checkbox-unchecked" aria-hidden="true"></span>
         <span class="checkbox-label">Read-only for joiners</span>
@@ -106,6 +114,7 @@ const base = rawBase.endsWith('/') ? rawBase : rawBase + '/';
   .app-icon img {
     border-radius: 6px;
     display: block;
+    animation: icon-breathe 4.8s ease-in-out infinite;
   }
 
   .app-meta {
@@ -155,6 +164,8 @@ const base = rawBase.endsWith('/') ? rawBase : rawBase + '/';
   .mac-btn-blue {
     background: #0A84FF;
     color: #fff;
+    box-shadow: 0 0 0 rgba(10, 132, 255, 0);
+    animation: start-confirm 6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
   }
 
   .mac-btn-secondary {
@@ -169,6 +180,46 @@ const base = rawBase.endsWith('/') ? rawBase : rawBase + '/';
     grid-template-columns: 1fr 1fr;
     gap: 8px;
     margin-bottom: 12px;
+  }
+
+  .session-card {
+    display: grid;
+    gap: 5px;
+    margin-bottom: 12px;
+    padding: 8px 9px;
+    border-radius: 7px;
+    background: rgba(10, 132, 255, 0.1);
+    border: 0.5px solid rgba(10, 132, 255, 0.22);
+    animation: session-peek 6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+    transform-origin: top;
+  }
+
+  .session-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #f0f0f0;
+    font-size: 11.5px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  }
+
+  .status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #32d74b;
+    box-shadow: 0 0 0 0 rgba(50, 215, 75, 0.34);
+    animation: status-pulse 1.8s ease-out infinite;
+  }
+
+  .session-card code {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: #8e8e93;
+    font-family: 'SF Mono', ui-monospace, Menlo, monospace;
+    font-size: 10.5px;
   }
 
   .checkbox-row {
@@ -230,6 +281,71 @@ const base = rawBase.endsWith('/') ? rawBase : rawBase + '/';
     background: radial-gradient(circle, rgba(228, 146, 75, 0.08) 0%, transparent 70%);
     pointer-events: none;
     z-index: -1;
+  }
+
+  @keyframes start-confirm {
+    0%, 22%, 100% {
+      transform: none;
+      box-shadow: 0 0 0 rgba(10, 132, 255, 0);
+      filter: none;
+    }
+    27% {
+      transform: scale(0.96);
+      filter: brightness(1.05);
+    }
+    34% {
+      transform: none;
+      box-shadow: 0 0 0 6px rgba(10, 132, 255, 0.14);
+    }
+    46% {
+      box-shadow: 0 0 0 rgba(10, 132, 255, 0);
+    }
+  }
+
+  @keyframes session-peek {
+    0%, 20%, 100% {
+      opacity: 0;
+      transform: translateY(-4px) scaleY(0.96);
+      max-height: 0;
+      padding-top: 0;
+      padding-bottom: 0;
+      margin-bottom: 0;
+      border-width: 0;
+    }
+    30%, 72% {
+      opacity: 1;
+      transform: none;
+      max-height: 64px;
+      padding-top: 8px;
+      padding-bottom: 8px;
+      margin-bottom: 12px;
+      border-width: 0.5px;
+    }
+  }
+
+  @keyframes status-pulse {
+    0% { box-shadow: 0 0 0 0 rgba(50, 215, 75, 0.34); }
+    80%, 100% { box-shadow: 0 0 0 7px rgba(50, 215, 75, 0); }
+  }
+
+  @keyframes icon-breathe {
+    0%, 100% { filter: drop-shadow(0 0 0 rgba(228, 146, 75, 0)); }
+    50% { filter: drop-shadow(0 0 10px rgba(228, 146, 75, 0.24)); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .app-icon img,
+    .mac-btn-blue,
+    .session-card,
+    .status-dot {
+      animation: none;
+    }
+
+    .session-card {
+      opacity: 1;
+      transform: none;
+      max-height: none;
+    }
   }
 
   /* ---- Responsive ---- */

--- a/website/src/components/InstallCTA.astro
+++ b/website/src/components/InstallCTA.astro
@@ -1,5 +1,5 @@
 ---
-import { dmgUrl, githubUrl } from '../consts';
+import { dmgUrl, githubUrl, installCmd } from '../consts';
 ---
 
 <section class="cta" id="install">
@@ -35,7 +35,21 @@ import { dmgUrl, githubUrl } from '../consts';
       </a>
     </div>
 
-    <div class="cta-muted reveal r-d2">
+    <div class="cli-copy reveal r-d2">
+      <code>{installCmd}</code>
+      <button
+        type="button"
+        class="secondary-button copy-button"
+        data-copy-text={installCmd}
+        data-copy-source="final_cta"
+        data-copy-target="cli_install"
+        data-copy-surface="website"
+      >
+        <span data-copy-label>Copy CLI install</span>
+      </button>
+    </div>
+
+    <div class="cta-muted reveal r-d3">
       <span>Also available as a <a href={`${githubUrl}#install`} class="muted-link" target="_blank" rel="noopener noreferrer">CLI</a></span>
       <span class="sep">&middot;</span>
       <a
@@ -82,6 +96,37 @@ import { dmgUrl, githubUrl } from '../consts';
     justify-content: center;
   }
 
+  .cli-copy {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.75rem;
+    width: min(100%, 46rem);
+    margin-top: 1.4rem;
+    padding: 0.55rem;
+    border: 1px solid var(--border);
+    border-radius: 0.7rem;
+    background: var(--paper);
+    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.12);
+  }
+
+  .cli-copy code {
+    padding-left: 0.8rem;
+    overflow: hidden;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .copy-button {
+    min-height: 2.65rem;
+    padding: 0.65rem 0.95rem;
+    white-space: nowrap;
+  }
+
   .cta-muted {
     display: flex;
     align-items: center;
@@ -108,5 +153,23 @@ import { dmgUrl, githubUrl } from '../consts';
 
   .sep {
     color: var(--border-strong);
+  }
+
+  @media (max-width: 720px) {
+    .cli-copy {
+      grid-template-columns: 1fr;
+      padding: 0.8rem;
+    }
+
+    .cli-copy code {
+      width: 100%;
+      padding: 0;
+      white-space: normal;
+      word-break: break-all;
+    }
+
+    .copy-button {
+      width: 100%;
+    }
   }
 </style>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -86,6 +86,32 @@ const canonicalUrl = new URL(base, Astro.site ?? 'https://go-johnnyhe.github.io'
         label.textContent = copied ? 'Copied' : button.dataset.defaultLabel;
       }
 
+      async function copyText(text) {
+        if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+          try {
+            await navigator.clipboard.writeText(text);
+            return true;
+          } catch (_) {}
+        }
+
+        var textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'fixed';
+        textarea.style.top = '-9999px';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+
+        try {
+          return document.execCommand('copy');
+        } catch (_) {
+          return false;
+        } finally {
+          document.body.removeChild(textarea);
+        }
+      }
+
       document.addEventListener('DOMContentLoaded', () => {
         shadowCapture('landing_page_viewed', { surface: 'website' });
 
@@ -122,7 +148,8 @@ const canonicalUrl = new URL(base, Astro.site ?? 'https://go-johnnyhe.github.io'
           if (!text) return;
 
           try {
-            await navigator.clipboard.writeText(text);
+            var didCopy = await copyText(text);
+            if (!didCopy) return;
             updateCopyButtonState(copyButton, true);
             shadowCapture('install_command_copied', {
               source: copyButton.getAttribute('data-copy-source') || 'unknown',

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -167,6 +167,7 @@ a:focus-visible {
 .primary-button,
 .secondary-button,
 .ghost-button {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -176,7 +177,8 @@ a:focus-visible {
   border: 1px solid transparent;
   cursor: pointer;
   min-height: 3.2rem;
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  overflow: hidden;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .primary-button {
@@ -184,6 +186,7 @@ a:focus-visible {
   color: var(--bg);
   border-color: var(--accent);
   font-weight: 600;
+  box-shadow: 0 0 0 rgba(228, 146, 75, 0);
 }
 
 .secondary-button {
@@ -202,6 +205,7 @@ a:focus-visible {
   background: var(--accent-strong);
   border-color: var(--accent-strong);
   transform: translateY(-1px);
+  box-shadow: 0 12px 36px rgba(228, 146, 75, 0.16);
 }
 
 .secondary-button:hover {
@@ -216,10 +220,32 @@ a:focus-visible {
   transform: translateY(-1px);
 }
 
+.primary-button:active,
+.secondary-button:active,
+.ghost-button:active {
+  transform: translateY(1px) scale(0.99);
+}
+
 [data-copy-state='copied'] {
   background: var(--accent) !important;
   border-color: var(--accent) !important;
   color: var(--bg) !important;
+}
+
+[data-copy-state='copied']::after {
+  content: '';
+  position: absolute;
+  inset: -50% auto auto -30%;
+  width: 46%;
+  height: 200%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.28), transparent);
+  transform: rotate(18deg);
+  animation: copy-sheen 0.7s ease both;
+}
+
+@keyframes copy-sheen {
+  from { translate: 0 0; }
+  to { translate: 330% 0; }
 }
 
 /* ---- Reveal ---- */
@@ -238,6 +264,21 @@ a:focus-visible {
 .r-d2 { transition-delay: 0.2s; }
 .r-d3 { transition-delay: 0.3s; }
 .r-d4 { transition-delay: 0.4s; }
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.001ms !important;
+  }
+}
 
 /* ---- Scrollbar ---- */
 ::-webkit-scrollbar { width: 8px; }


### PR DESCRIPTION
## Summary
- Adds persistent design context for future Shadow UI work.
- Adds a restrained hero mockup state animation for the start-session flow.
- Adds a final CTA CLI copy affordance with fallback clipboard behavior.
- Adds reduced-motion handling and button micro-interactions.

## Validation
- npm run build
- Verified local page at http://127.0.0.1:4321/shadow#install
- Confirmed final CTA copy button changes to `Copied`

## Notes
- Excludes unrelated untracked `.opencode/package-lock.json`.
- Website deploy will run after merge because `website/**` changes publish from `main`.